### PR TITLE
Make runtime type checking usable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ python3 test/test_ops.py                # just the ops tests
 python3 -m pytest test/                 # whole test suite
 ```
 
+### Runtime type checking
+
+tinygrad supports optional runtime type checking using
+[typeguard](https://github.com/agronholm/typeguard). Enable it by setting
+`TYPED=1` in the environment:
+
+```sh
+TYPED=1 python3 -m pytest test/test_tiny.py
+```
+
 #### Process replay tests
 
 [Process replay](https://github.com/tinygrad/tinygrad/blob/master/test/external/process_replay/README.md) compares your PR's generated kernels against master. If your PR is a refactor or speedup without any expected behavior change, It should include [pr] in the pull request title.

--- a/tinygrad/device.py
+++ b/tinygrad/device.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 from dataclasses import dataclass, replace
 from collections import defaultdict
-from typing import Optional, Any, Iterator, Generator
+from typing import Optional, Any, Iterator, Generator, TYPE_CHECKING
 import multiprocessing, importlib, inspect, functools, pathlib, os, ctypes, ctypes.util, platform, contextlib, sys, re, atexit, pickle, decimal, time
 from tinygrad.helpers import CI, OSX, LRU, getenv, diskcache_get, diskcache_put, DEBUG, GlobalCounters, flat_mv, from_mv, PROFILE, temp, mv_address, \
                              cpu_time_execution, colored, Context, round_up
 from tinygrad.dtype import DType, ImageDType, PtrDType, dtypes, _to_np_dtype
 from tinygrad.renderer import Renderer
+
+if int(os.getenv("TYPED", "0")) or TYPE_CHECKING:
+  import numpy as np
 
 # **************** Device ****************
 

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -63,7 +63,7 @@ def partition(itr:Iterable[T], fxn:Callable[[T],bool]) -> tuple[list[T], list[T]
 def unwrap(x:Optional[T]) -> T:
   assert x is not None
   return x
-def get_single_element(x:list[T]) -> T:
+def get_single_element(x:Sequence[T]) -> T:
   assert len(x) == 1, f"list {x} must only have 1 element"
   return x[0]
 def get_child(obj, key):
@@ -298,7 +298,7 @@ def to_char_p_p(options: list[bytes], to_type=ctypes.c_char):
 @functools.cache
 def init_c_struct_t(fields: tuple[tuple[str, ctypes._SimpleCData], ...]):
   class CStruct(ctypes.Structure):
-    _pack_, _fields_ = 1, fields
+    _pack_, _fields_ = 1, fields  # type: ignore[assignment]
   return CStruct
 def init_c_var(ctypes_var, creat_cb): return (creat_cb(ctypes_var), ctypes_var)[1]
 def flat_mv(mv:memoryview): return mv if len(mv) == 0 else mv.cast("B", shape=(mv.nbytes,))

--- a/tinygrad/spec.py
+++ b/tinygrad/spec.py
@@ -162,7 +162,9 @@ shape_spec = PatternMatcher([
 
 # ***** uop helpers *****
 
-def type_verify(uops:list[UOp], *extra_specs:PatternMatcher):
+from collections.abc import Sequence
+
+def type_verify(uops:Sequence[UOp], *extra_specs:PatternMatcher):
   specs = [spec, *extra_specs]
   for i,u in enumerate(uops):
     spec_ret = [cast(bool|None, s.rewrite(u)) for s in specs]


### PR DESCRIPTION
## Summary
- support `TYPED=1` runtime checking
- import `numpy` when type checking is enabled
- widen type signatures to avoid typeguard errors
- allow sequences in verification helpers
- document how to run with `TYPED=1`

## Testing
- `python3 -m ruff check .`
- `python3 -m mypy tinygrad/ --strict-equality`
- `TYPED=1 python3 -m pytest test/test_tiny.py`
- `python3 -m pytest test/test_tiny.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff26587d4832e8c5477b6db5caab0