### PR TITLE
Add SVD support

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -345,6 +345,19 @@ def sort_values(input, dim=-1, descending=False, stable=True, values=None, indic
   unwrap(indices).assign(out_indices.cast(dtypes.int64))
   return wrap(out_values), wrap(out_indices)
 
+@torch.library.impl("aten::_linalg_svd.default", "privateuseone")
+def linalg_svd_default(A: torch.Tensor, full_matrices=False, compute_uv=True, *, driver=None):
+  return tuple(wrap(x) for x in unwrap(A).svd(full_matrices, compute_uv))
+
+@torch.library.impl("aten::_linalg_svd.U", "privateuseone")
+@inplace_fn(["U", "S", "Vh"])
+def linalg_svd_out(A: torch.Tensor, full_matrices=False, compute_uv=True, *, driver=None, U=None, S=None, Vh=None):
+  outU, outS, outVh = unwrap(A).svd(full_matrices, compute_uv)
+  unwrap(U).assign(outU)
+  unwrap(S).assign(outS)
+  unwrap(Vh).assign(outVh)
+  return wrap(outU), wrap(outS), wrap(outVh)
+
 # register some decompositions
 from torch._decomp import get_decompositions
 decomps = [

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1122,6 +1122,11 @@ class TestOps(unittest.TestCase):
     np.testing.assert_equal(indices.numpy(), [2, 4, 6])
     self.helper_test_exception([(4)], lambda x: x.topk(5), lambda x: x.topk(5), expected=(RuntimeError, ValueError))
 
+  def test_svd(self):
+    helper_test_op([(5, 3)], lambda x: torch.linalg.svd(x).U, lambda x: x.svd()[0], forward_only=True)
+    helper_test_op([(5, 3)], lambda x: torch.linalg.svd(x).S, lambda x: x.svd()[1], forward_only=True)
+    helper_test_op([(5, 3)], lambda x: torch.linalg.svd(x).Vh, lambda x: x.svd()[2], forward_only=True)
+
   def test_einsum(self):
     # matrix transpose
     helper_test_op([(150,150)], lambda a: torch.einsum('ij->ji', a), lambda a: Tensor.einsum('ij->ji', a))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2759,6 +2759,18 @@ class Tensor(MathTrait):
     shrink_to_k = tuple((0, k) if i == dim else None for i in range(self.ndim))
     return x.shrink(shrink_to_k), idx.shrink(shrink_to_k)
 
+  def svd(self, full_matrices: bool = True, compute_uv: bool = True) -> tuple[Tensor, Tensor, Tensor]|Tensor:
+    """Computes the singular value decomposition of the tensor using numpy."""
+    import numpy as np
+    res = np.linalg.svd(self.numpy(), full_matrices=full_matrices, compute_uv=compute_uv)
+    if compute_uv:
+      U, S, Vh = res
+      return (Tensor(U, device=self.device, dtype=self.dtype),
+              Tensor(S, device=self.device, dtype=self.dtype),
+              Tensor(Vh, device=self.device, dtype=self.dtype))
+    else:
+      return Tensor(res, device=self.device, dtype=self.dtype)
+
   # ***** unary ops *****
 
   def logical_not(self) -> Tensor:


### PR DESCRIPTION
## Summary
- implement `Tensor.svd`
- expose SVD via torch backend
- test singular value decomposition

## Testing
- `ruff check --fix .`
- `python3 -m pytest test/test_ops.py::TestOps::test_svd -q`

------
https://chatgpt.com/codex/tasks/task_e_684002600a64832eac7ba56b3a61412c